### PR TITLE
Fix issue with new repo name (#4)

### DIFF
--- a/core/execute_load.py
+++ b/core/execute_load.py
@@ -5,8 +5,8 @@
 import sys
 import os
 user_home = os.path.expanduser("~").replace(os.sep,'/')
-sys.path.append(user_home + r"/automaton/core/storage")
-sys.path.append(user_home + r"/automaton/core/message")
+sys.path.append(user_home + r"/automatic-octopus/core/storage")
+sys.path.append(user_home + r"/automatic-octopus/core/message")
 from load_tables import extract_load#pylint: disable=import-error
 from transmit import communicado#pylint: disable=import-error
 

--- a/core/storage/load_tables.py
+++ b/core/storage/load_tables.py
@@ -8,7 +8,7 @@ import os
 import logging
 from datetime import datetime
 user_home = os.path.expanduser("~").replace(os.sep,'/')
-sys.path.append(user_home + r"/automaton/core/data_pull")
+sys.path.append(user_home + r"/automatic-octopus/core/data_pull")
 from tracks import track_features, recently_played#pylint: disable=import-error
 from postgres_connections import pg_conn
 from psycopg2 import ProgrammingError, errors


### PR DESCRIPTION
Why
The old automaton repo name was referenced in a few imports. This was breaking
the execute script.

How
- Fix the issues on execute_load.py and load_tables.py by changing automaton
to automatic-octopus