### PR TITLE
Add python shebang to script

### DIFF
--- a/core/execute_load.py
+++ b/core/execute_load.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #This script will pull the API data and load the tables. Eventually, a message
 #should be added that provides updates if the run fails
 


### PR DESCRIPTION
Why
Since execute_load will be run through the command line,
it should have a shebang at the top

How
- Add #!/usr/bin/env python3 to the top of execute_load.py